### PR TITLE
docs(plan): drop "agent assignments" from /plan description

### DIFF
--- a/skills/plan/SKILL.md
+++ b/skills/plan/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: plan
-description: "Explore approaches, evaluate tradeoffs, then produce a scored execution plan with task dependencies and agent assignments."
+description: "Explore approaches, evaluate tradeoffs, then produce a scored execution plan with verifiable, implementation-agnostic tasks and dependencies."
 model: opus
 context: fork
 allowed-tools: Read, Grep, Glob, Bash


### PR DESCRIPTION
## Summary

Follow-up to v6 (#7). v6 de-agented `/plan` — removed the `agent:` task field and swapped the "Agent Assignment" rubric criterion for "Scope / Right-sizing" — but the frontmatter `description` still advertised "task dependencies **and agent assignments**". This 1-line fix makes the skill description consistent with its now implementation-agnostic body.

- Before: `...scored execution plan with task dependencies and agent assignments.`
- After: `...scored execution plan with verifiable, implementation-agnostic tasks and dependencies.`

No behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)